### PR TITLE
Add support for Launchpad Mini Mk3 (like X but smaller)

### DIFF
--- a/src/app/devices/known-devices/known-devices.ts
+++ b/src/app/devices/known-devices/known-devices.ts
@@ -2,6 +2,7 @@ import { Controller, Selector } from '../device/device.types';
 import { novationLaunchpadX } from './novation-launchpad-x';
 import { novationLaunchControlXl } from './novation-launch-control-xl';
 import { novationLaunchpadMini } from './novation-launchpad-mini';
+import { novationLaunchpadMiniMk3 } from './novation-launchpad-mini-mk3';
 
 /**
  * List of known devices.
@@ -10,4 +11,5 @@ export const knownDevices: (Selector | Controller)[] = [
   novationLaunchpadX,
   novationLaunchControlXl,
   novationLaunchpadMini,
+  novationLaunchpadMiniMk3,
 ];

--- a/src/app/devices/known-devices/known-devices.ts
+++ b/src/app/devices/known-devices/known-devices.ts
@@ -1,7 +1,7 @@
 import { Controller, Selector } from '../device/device.types';
 import { novationLaunchpadX } from './novation-launchpad-x';
 import { novationLaunchControlXl } from './novation-launch-control-xl';
-import { novationLaunchpadMini } from './novation-launchpad-mini';
+import { novationLaunchpadMiniMk2 } from './novation-launchpad-mini-mk2';
 import { novationLaunchpadMiniMk3 } from './novation-launchpad-mini-mk3';
 
 /**
@@ -10,6 +10,6 @@ import { novationLaunchpadMiniMk3 } from './novation-launchpad-mini-mk3';
 export const knownDevices: (Selector | Controller)[] = [
   novationLaunchpadX,
   novationLaunchControlXl,
-  novationLaunchpadMini,
+  novationLaunchpadMiniMk2,
   novationLaunchpadMiniMk3,
 ];

--- a/src/app/devices/known-devices/novation-launchpad-mini-mk2.ts
+++ b/src/app/devices/known-devices/novation-launchpad-mini-mk2.ts
@@ -1,14 +1,14 @@
 import { Selector, DeviceCategory } from '../device/device.types';
 
 /**
- * Novation Launchpad Mini
+ * Novation Launchpad Mini Mk2
  *
  * @see http://leemans.ch/latex/doc_launchpad-programmers-reference.pdf
  */
-export const novationLaunchpadMini: Selector = {
+export const novationLaunchpadMiniMk2: Selector = {
   category: DeviceCategory.selector,
   manufacturer: 'Focusrite A.E. Ltd',
-  name: 'Launchpad Mini',
+  name: 'Launchpad Mini MK2',
   channels: {
     input: 'all',
     output: 1,

--- a/src/app/devices/known-devices/novation-launchpad-mini-mk2.ts
+++ b/src/app/devices/known-devices/novation-launchpad-mini-mk2.ts
@@ -1,4 +1,4 @@
-import { Selector, DeviceCategory } from '../device/device.types';
+import {Selector, DeviceCategory} from '../device/device.types';
 
 /**
  * Novation Launchpad Mini Mk2
@@ -8,7 +8,7 @@ import { Selector, DeviceCategory } from '../device/device.types';
 export const novationLaunchpadMiniMk2: Selector = {
   category: DeviceCategory.selector,
   manufacturer: 'Focusrite A.E. Ltd',
-  name: 'Launchpad Mini MK2',
+  name: 'Launchpad Mini MIDI',
   channels: {
     input: 'all',
     output: 1,
@@ -41,7 +41,7 @@ export const novationLaunchpadMiniMk2: Selector = {
     yellow: 62,
     green: 60,
   },
-  get colorByState () {
+  get colorByState() {
     return {
       inputOn: this.colors.red,
       inputOff: this.colors.black,
@@ -61,7 +61,7 @@ export const novationLaunchpadMiniMk2: Selector = {
     defaultDuration: 500,
     longClick: 400,
   },
-  get bootSequence () {
+  get bootSequence() {
     return {
       color: this.colors.red,
       sysex: {

--- a/src/app/devices/known-devices/novation-launchpad-mini-mk3.ts
+++ b/src/app/devices/known-devices/novation-launchpad-mini-mk3.ts
@@ -1,0 +1,21 @@
+import { Selector, DeviceCategory } from '../device/device.types';
+import { novationLaunchpadX } from './novation-launchpad-x';
+
+/**
+ * Novation Launchpad Mini Mk3
+ *
+ * @see Novation resources https://downloads.novationmusic.com/novation/launchpad-mk3/launchpad-mini-mk3-0
+ */
+export const novationLaunchpadMiniMk3 = {
+  ...novationLaunchpadX, // shallow copy but it is probably not meant to be mutated anyway
+  name: 'Launchpad Mini MK3', // https://github.com/rienheuver/launchpad-mini-mk3/blob/master/index.js#L7 , mine is 'Launchpad Mini MK3 LPMiniMK3 MI'
+  get bootSequence () {
+    return {
+      color: novationLaunchpadX.colors.red,
+      sysex: {
+        manufacturer: 0,
+        data: [32, 41, 2, 13, 14, 1], // https://github.com/FMMT666/launchpad.py/blob/master/launchpad_py/launchpad.py#L2375
+      },
+    };
+  },
+} as Selector;


### PR DESCRIPTION
Also renames mini to mini mk2 to avoid confusion (currently the novation website actually brands the mk3 as the mini)